### PR TITLE
Change: Spam tab to show only relevant spams for the user

### DIFF
--- a/projects/noloan/app/src/main/java/hasadna/noloan/InboxRecyclerAdapter.java
+++ b/projects/noloan/app/src/main/java/hasadna/noloan/InboxRecyclerAdapter.java
@@ -24,7 +24,7 @@ import hasadna.noloan.protobuf.SmsProto.SmsMessage;
 import noloan.R;
 
 public class InboxRecyclerAdapter
-        extends RecyclerView.Adapter<InboxRecyclerAdapter.RecyclerViewHolder> {
+    extends RecyclerView.Adapter<InboxRecyclerAdapter.RecyclerViewHolder> {
   private static final String TAG = "InboxRecyclerAdapter";
 
   public InboxRecyclerAdapter() {
@@ -71,36 +71,36 @@ public class InboxRecyclerAdapter
 
     public void bind(SmsMessage sms) {
       from.setText(
-              String.format(itemView.getContext().getString(R.string.list_item_from), sms.getSender()));
+          String.format(itemView.getContext().getString(R.string.list_item_from), sms.getSender()));
       content.setText(sms.getBody());
 
       // Search if message was suggested / user suggested: update counter / add undo button
       if (SmsMessages.get().searchDbMessage(sms) != -1) {
         counter.setText(
-                itemView
-                        .getResources()
-                        .getString(
-                                R.string.list_item_textView_spam_counter,
-                                SmsMessages.get()
-                                        .getDbMessages()
-                                        .get(SmsMessages.get().searchDbMessage(sms))
-                                        .getSuggestersCount()));
+            itemView
+                .getResources()
+                .getString(
+                    R.string.list_item_textView_spam_counter,
+                    SmsMessages.get()
+                        .getDbMessages()
+                        .get(SmsMessages.get().searchDbMessage(sms))
+                        .getSuggestersCount()));
 
         // Toggle undo button
         if (SmsMessages.get()
-                .getDbMessages()
-                .get(SmsMessages.get().searchDbMessage(sms))
-                .getSuggestersList()
-                .contains(FirebaseAuthentication.getInstance().getCurrentUserId())) {
+            .getDbMessages()
+            .get(SmsMessages.get().searchDbMessage(sms))
+            .getSuggestersList()
+            .contains(FirebaseAuthentication.getInstance().getCurrentUserId())) {
           buttonAddSuggestion.setVisibility(View.INVISIBLE);
           buttonUndoSuggestion.setVisibility((View.VISIBLE));
           buttonUndoSuggestion.setOnClickListener(
-                  view ->
+              view ->
+                  SmsMessages.get()
+                      .undoSuggestion(
                           SmsMessages.get()
-                                  .undoSuggestion(
-                                          SmsMessages.get()
-                                                  .getDbMessages()
-                                                  .get(SmsMessages.get().searchDbMessage((sms)))));
+                              .getDbMessages()
+                              .get(SmsMessages.get().searchDbMessage((sms)))));
         } else {
           buttonAddSuggestion.setVisibility(View.VISIBLE);
           buttonUndoSuggestion.setVisibility((View.INVISIBLE));
@@ -109,7 +109,7 @@ public class InboxRecyclerAdapter
       // Case: No one suggested this message
       else {
         counter.setText(
-                itemView.getResources().getString(R.string.list_item_textView_spam_counter, 0));
+            itemView.getResources().getString(R.string.list_item_textView_spam_counter, 0));
         buttonAddSuggestion.setVisibility(View.VISIBLE);
         buttonUndoSuggestion.setVisibility((View.INVISIBLE));
       }
@@ -120,11 +120,11 @@ public class InboxRecyclerAdapter
         Locale local = new Locale("he");
         calendar.setTime(new SimpleDateFormat("dd/M/yyyy", local).parse(sms.getReceivedAt()));
         receivedAt.setText(
-                String.format(
-                        itemView.getContext().getString(R.string.list_item_date),
-                        calendar.get(Calendar.DAY_OF_MONTH),
-                        calendar.getDisplayName(Calendar.MONTH, Calendar.LONG, local),
-                        calendar.get(Calendar.YEAR)));
+            String.format(
+                itemView.getContext().getString(R.string.list_item_date),
+                calendar.get(Calendar.DAY_OF_MONTH),
+                calendar.getDisplayName(Calendar.MONTH, Calendar.LONG, local),
+                calendar.get(Calendar.YEAR)));
       } catch (ParseException e) {
         Log.e(TAG, "Error parsing sms.ReceivedAt() to Date object\n" + e.getMessage());
       }
@@ -133,18 +133,19 @@ public class InboxRecyclerAdapter
       // TODO: See which more fields in the lawsuit form can be understood from the SMS / other
       // DATA.
       buttonCreateLawsuit.setOnClickListener(
-              view -> {
-                Intent intentToLawsuitForm = new Intent(view.getContext(), LawsuitActivity.class);
-                // TODO: Check if preferably to pass the SmsMessage.Proto object itself, rather than its
-                // fields.
-                intentToLawsuitForm.putExtra("receivedAt", sms.getReceivedAt());
-                intentToLawsuitForm.putExtra("from", sms.getSender());
-                intentToLawsuitForm.putExtra("body", sms.getBody());
-                intentToLawsuitForm.putExtra("id", sms.getId());
-                view.getContext().startActivity(intentToLawsuitForm);
-              });
+          view -> {
+            Intent intentToLawsuitForm = new Intent(view.getContext(), LawsuitActivity.class);
+            // TODO: Check if preferably to pass the SmsMessage.Proto object itself, rather than its
+            // fields.
+            intentToLawsuitForm.putExtra("receivedAt", sms.getReceivedAt());
+            intentToLawsuitForm.putExtra("from", sms.getSender());
+            intentToLawsuitForm.putExtra("body", sms.getBody());
+            intentToLawsuitForm.putExtra("id", sms.getId());
+            view.getContext().startActivity(intentToLawsuitForm);
+          });
 
       buttonAddSuggestion.setOnClickListener(view -> SmsMessages.get().suggestMessage(sms));
     }
   }
 }
+

--- a/projects/noloan/app/src/main/java/hasadna/noloan/InboxRecyclerAdapter.java
+++ b/projects/noloan/app/src/main/java/hasadna/noloan/InboxRecyclerAdapter.java
@@ -24,7 +24,7 @@ import hasadna.noloan.protobuf.SmsProto.SmsMessage;
 import noloan.R;
 
 public class InboxRecyclerAdapter
-    extends RecyclerView.Adapter<InboxRecyclerAdapter.RecyclerViewHolder> {
+        extends RecyclerView.Adapter<InboxRecyclerAdapter.RecyclerViewHolder> {
   private static final String TAG = "InboxRecyclerAdapter";
 
   public InboxRecyclerAdapter() {
@@ -71,36 +71,36 @@ public class InboxRecyclerAdapter
 
     public void bind(SmsMessage sms) {
       from.setText(
-          String.format(itemView.getContext().getString(R.string.list_item_from), sms.getSender()));
+              String.format(itemView.getContext().getString(R.string.list_item_from), sms.getSender()));
       content.setText(sms.getBody());
 
       // Search if message was suggested / user suggested: update counter / add undo button
       if (SmsMessages.get().searchDbMessage(sms) != -1) {
         counter.setText(
-            itemView
-                .getResources()
-                .getString(
-                    R.string.list_item_textView_spam_counter,
-                    SmsMessages.get()
-                        .getDbMessages()
-                        .get(SmsMessages.get().searchDbMessage(sms))
-                        .getSuggestersCount()));
+                itemView
+                        .getResources()
+                        .getString(
+                                R.string.list_item_textView_spam_counter,
+                                SmsMessages.get()
+                                        .getDbMessages()
+                                        .get(SmsMessages.get().searchDbMessage(sms))
+                                        .getSuggestersCount()));
 
         // Toggle undo button
         if (SmsMessages.get()
-            .getDbMessages()
-            .get(SmsMessages.get().searchDbMessage(sms))
-            .getSuggestersList()
-            .contains(FirebaseAuthentication.getInstance().getCurrentUserId())) {
+                .getDbMessages()
+                .get(SmsMessages.get().searchDbMessage(sms))
+                .getSuggestersList()
+                .contains(FirebaseAuthentication.getInstance().getCurrentUserId())) {
           buttonAddSuggestion.setVisibility(View.INVISIBLE);
           buttonUndoSuggestion.setVisibility((View.VISIBLE));
           buttonUndoSuggestion.setOnClickListener(
-              view ->
-                  SmsMessages.get()
-                      .undoSuggestion(
+                  view ->
                           SmsMessages.get()
-                              .getDbMessages()
-                              .get(SmsMessages.get().searchDbMessage((sms)))));
+                                  .undoSuggestion(
+                                          SmsMessages.get()
+                                                  .getDbMessages()
+                                                  .get(SmsMessages.get().searchDbMessage((sms)))));
         } else {
           buttonAddSuggestion.setVisibility(View.VISIBLE);
           buttonUndoSuggestion.setVisibility((View.INVISIBLE));
@@ -109,7 +109,7 @@ public class InboxRecyclerAdapter
       // Case: No one suggested this message
       else {
         counter.setText(
-            itemView.getResources().getString(R.string.list_item_textView_spam_counter, 0));
+                itemView.getResources().getString(R.string.list_item_textView_spam_counter, 0));
         buttonAddSuggestion.setVisibility(View.VISIBLE);
         buttonUndoSuggestion.setVisibility((View.INVISIBLE));
       }
@@ -120,11 +120,11 @@ public class InboxRecyclerAdapter
         Locale local = new Locale("he");
         calendar.setTime(new SimpleDateFormat("dd/M/yyyy", local).parse(sms.getReceivedAt()));
         receivedAt.setText(
-            String.format(
-                itemView.getContext().getString(R.string.list_item_date),
-                calendar.get(Calendar.DAY_OF_MONTH),
-                calendar.getDisplayName(Calendar.MONTH, Calendar.LONG, local),
-                calendar.get(Calendar.YEAR)));
+                String.format(
+                        itemView.getContext().getString(R.string.list_item_date),
+                        calendar.get(Calendar.DAY_OF_MONTH),
+                        calendar.getDisplayName(Calendar.MONTH, Calendar.LONG, local),
+                        calendar.get(Calendar.YEAR)));
       } catch (ParseException e) {
         Log.e(TAG, "Error parsing sms.ReceivedAt() to Date object\n" + e.getMessage());
       }
@@ -133,19 +133,18 @@ public class InboxRecyclerAdapter
       // TODO: See which more fields in the lawsuit form can be understood from the SMS / other
       // DATA.
       buttonCreateLawsuit.setOnClickListener(
-          view -> {
-            Intent intentToLawsuitForm = new Intent(view.getContext(), LawsuitActivity.class);
-            // TODO: Check if preferably to pass the SmsMessage.Proto object itself, rather than its
-            // fields.
-            intentToLawsuitForm.putExtra("receivedAt", sms.getReceivedAt());
-            intentToLawsuitForm.putExtra("from", sms.getSender());
-            intentToLawsuitForm.putExtra("body", sms.getBody());
-            intentToLawsuitForm.putExtra("id", sms.getId());
-            view.getContext().startActivity(intentToLawsuitForm);
-          });
+              view -> {
+                Intent intentToLawsuitForm = new Intent(view.getContext(), LawsuitActivity.class);
+                // TODO: Check if preferably to pass the SmsMessage.Proto object itself, rather than its
+                // fields.
+                intentToLawsuitForm.putExtra("receivedAt", sms.getReceivedAt());
+                intentToLawsuitForm.putExtra("from", sms.getSender());
+                intentToLawsuitForm.putExtra("body", sms.getBody());
+                intentToLawsuitForm.putExtra("id", sms.getId());
+                view.getContext().startActivity(intentToLawsuitForm);
+              });
 
       buttonAddSuggestion.setOnClickListener(view -> SmsMessages.get().suggestMessage(sms));
     }
   }
 }
-

--- a/projects/noloan/app/src/main/java/hasadna/noloan/SpamRecyclerAdapter.java
+++ b/projects/noloan/app/src/main/java/hasadna/noloan/SpamRecyclerAdapter.java
@@ -38,20 +38,17 @@ public class SpamRecyclerAdapter
     inboxSpam = new ArrayList<>();
 
     // Fetch spams from DB that are in user's inbox
-    for (int i = 0; i < SmsMessages.get().getInboxMessages().size(); i++) {
-      for (SmsMessage sms : SmsMessages.get().getDbMessages()) {
-        if (SmsMessages.get().getInboxMessages().get(i).getBody().contentEquals(sms.getBody())
-            && SmsMessages.get()
-                .getInboxMessages()
-                .get(i)
-                .getSender()
-                .contentEquals(sms.getSender())) {
-          // Add message from the DB - keep received date of user's message
-          inboxSpam.add(
-              sms.toBuilder()
-                  .setReceivedAt(SmsMessages.get().getInboxMessages().get(i).getReceivedAt())
-                  .build());
-        }
+    for (SmsMessage sms : SmsMessages.get().getInboxMessages()) {
+      int dbIndex = SmsMessages.searchMessage(sms, SmsMessages.get().getDbMessages());
+      if (dbIndex != -1) {
+        // Add message from the DB - keep received date of user's message
+        inboxSpam.add(
+            SmsMessages.get()
+                .getDbMessages()
+                .get(dbIndex)
+                .toBuilder()
+                .setReceivedAt(sms.getReceivedAt())
+                .build());
       }
     }
 
@@ -82,6 +79,7 @@ public class SpamRecyclerAdapter
                     SmsMessages.get()
                         .searchMessage(SmsMessages.get().getDbMessages().get(index), inboxSpam);
                 if (inboxSpamIndex != -1) {
+                  // Modify message - keep received date of user's message
                   inboxSpam.set(
                       inboxSpamIndex,
                       SmsMessages.get()

--- a/projects/noloan/app/src/main/java/hasadna/noloan/SpamRecyclerAdapter.java
+++ b/projects/noloan/app/src/main/java/hasadna/noloan/SpamRecyclerAdapter.java
@@ -31,7 +31,7 @@ public class SpamRecyclerAdapter
     extends RecyclerView.Adapter<SpamRecyclerAdapter.RecyclerViewHolder> {
   private static final String TAG = "SpamRecyclerAdapter";
 
-  List<SmsMessage> inboxSpam;
+  ArrayList<SmsMessage> inboxSpam;
 
   public SpamRecyclerAdapter() {
     Handler handler = new Handler(Looper.myLooper());

--- a/projects/noloan/app/src/main/java/hasadna/noloan/SpamRecyclerAdapter.java
+++ b/projects/noloan/app/src/main/java/hasadna/noloan/SpamRecyclerAdapter.java
@@ -28,7 +28,7 @@ import hasadna.noloan.protobuf.SmsProto.SmsMessage;
 import noloan.R;
 
 public class SpamRecyclerAdapter
-        extends RecyclerView.Adapter<SpamRecyclerAdapter.RecyclerViewHolder> {
+    extends RecyclerView.Adapter<SpamRecyclerAdapter.RecyclerViewHolder> {
   private static final String TAG = "SpamRecyclerAdapter";
 
   ArrayList<SmsMessage> inboxSpam;
@@ -40,46 +40,73 @@ public class SpamRecyclerAdapter
     // Fetch spams from DB that are in user's inbox
     for (int i = 0; i < SmsMessages.get().getInboxMessages().size(); i++) {
       for (SmsMessage sms : SmsMessages.get().getDbMessages()) {
-        if (SmsMessages.get().getInboxMessages().get(i).getBody().contentEquals(sms.getBody()) && SmsMessages.get().getInboxMessages().get(i).getSender().contentEquals(sms.getSender())) {
+        if (SmsMessages.get().getInboxMessages().get(i).getBody().contentEquals(sms.getBody())
+            && SmsMessages.get()
+                .getInboxMessages()
+                .get(i)
+                .getSender()
+                .contentEquals(sms.getSender())) {
           // Add message from the DB - keep received date of user's message
-          inboxSpam.add(sms.toBuilder().setReceivedAt(SmsMessages.get().getInboxMessages().get(i).getReceivedAt()).build());
+          inboxSpam.add(
+              sms.toBuilder()
+                  .setReceivedAt(SmsMessages.get().getInboxMessages().get(i).getReceivedAt())
+                  .build());
         }
       }
     }
 
-
     // Listen to db smsMessages. Update just relevant messages that are in the inbox as well.
     // Keep the received date of the user's message.
     SmsMessages.get()
-            .setMessagesListener(
-                    new SmsMessages.MessagesListener() {
-                      @Override
-                      public void messageAdded(SmsMessage newMessage) {
-                        int inboxIndex = SmsMessages.get().searchMessage(newMessage,SmsMessages.get().getInboxMessages());
-                        if(inboxIndex!=-1) {
-                          inboxSpam.add(newMessage.toBuilder().setReceivedAt(SmsMessages.get().getInboxMessages().get(inboxIndex).getReceivedAt()).build());
-                          handler.post(() -> notifyItemInserted(inboxSpam.size()));
-                        }
-                      }
+        .setMessagesListener(
+            new SmsMessages.MessagesListener() {
+              @Override
+              public void messageAdded(SmsMessage newMessage) {
+                int inboxIndex =
+                    SmsMessages.get()
+                        .searchMessage(newMessage, SmsMessages.get().getInboxMessages());
+                if (inboxIndex != -1) {
+                  inboxSpam.add(
+                      newMessage
+                          .toBuilder()
+                          .setReceivedAt(
+                              SmsMessages.get().getInboxMessages().get(inboxIndex).getReceivedAt())
+                          .build());
+                  handler.post(() -> notifyItemInserted(inboxSpam.size()));
+                }
+              }
 
-                      @Override
-                      public void messageModified(int index) {
-                        int inboxSpamIndex = SmsMessages.get().searchMessage(SmsMessages.get().getDbMessages().get(index), inboxSpam);
-                        if(inboxSpamIndex !=-1) {
-                          inboxSpam.set(inboxSpamIndex, SmsMessages.get().getDbMessages().get(index).toBuilder().setReceivedAt(SmsMessages.get().getInboxMessages().get(inboxSpamIndex).getReceivedAt()).build());
-                          handler.post(() -> notifyItemChanged(inboxSpamIndex));
-                        }
-                      }
+              @Override
+              public void messageModified(int index) {
+                int inboxSpamIndex =
+                    SmsMessages.get()
+                        .searchMessage(SmsMessages.get().getDbMessages().get(index), inboxSpam);
+                if (inboxSpamIndex != -1) {
+                  inboxSpam.set(
+                      inboxSpamIndex,
+                      SmsMessages.get()
+                          .getDbMessages()
+                          .get(index)
+                          .toBuilder()
+                          .setReceivedAt(
+                              SmsMessages.get()
+                                  .getInboxMessages()
+                                  .get(inboxSpamIndex)
+                                  .getReceivedAt())
+                          .build());
+                  handler.post(() -> notifyItemChanged(inboxSpamIndex));
+                }
+              }
 
-                      @Override
-                      public void messageRemoved(int index, SmsMessage smsMessage) {
-                        int inboxSpamIndex = SmsMessages.get().searchMessage(smsMessage, inboxSpam);
-                        if(inboxSpamIndex!=-1) {
-                          inboxSpam.remove(inboxSpamIndex);
-                          handler.post(() -> notifyItemRemoved(inboxSpamIndex));
-                        }
-                      }
-                    });
+              @Override
+              public void messageRemoved(int index, SmsMessage smsMessage) {
+                int inboxSpamIndex = SmsMessages.get().searchMessage(smsMessage, inboxSpam);
+                if (inboxSpamIndex != -1) {
+                  inboxSpam.remove(inboxSpamIndex);
+                  handler.post(() -> notifyItemRemoved(inboxSpamIndex));
+                }
+              }
+            });
   }
 
   @NonNull
@@ -127,55 +154,55 @@ public class SpamRecyclerAdapter
         Locale local = new Locale("he");
         calendar.setTime(new SimpleDateFormat("dd/M/yyyy", local).parse(sms.getReceivedAt()));
         receivedAt.setText(
-                String.format(
-                        itemView.getContext().getString(R.string.list_item_date),
-                        calendar.get(Calendar.DAY_OF_MONTH),
-                        calendar.getDisplayName(Calendar.MONTH, Calendar.LONG, local),
-                        calendar.get(Calendar.YEAR)));
+            String.format(
+                itemView.getContext().getString(R.string.list_item_date),
+                calendar.get(Calendar.DAY_OF_MONTH),
+                calendar.getDisplayName(Calendar.MONTH, Calendar.LONG, local),
+                calendar.get(Calendar.YEAR)));
       } catch (ParseException e) {
         Log.e(TAG, "Error parsing sms.ReceivedAt() to Date object\n" + e.getMessage());
       }
 
       counter.setText(
-              itemView
-                      .getResources()
-                      .getString(R.string.list_item_textView_spam_counter, sms.getSuggestersCount()));
+          itemView
+              .getResources()
+              .getString(R.string.list_item_textView_spam_counter, sms.getSuggestersCount()));
 
       // Click on a message, from there (with message's details) move to the lawsuitPdfActivity
       // TODO: See which more fields in the lawsuit form can be understood from the SMS / other
       // DATA.
       buttonCreateLawsuit.setOnClickListener(
-              view -> {
-                Intent intentToLawsuitForm = new Intent(view.getContext(), LawsuitActivity.class);
-                // TODO: Check if preferably to pass the SmsMessage.Proto object itself, rather than its
-                // fields.
-                intentToLawsuitForm.putExtra("receivedAt", sms.getReceivedAt());
-                intentToLawsuitForm.putExtra("from", sms.getSender());
-                intentToLawsuitForm.putExtra("body", sms.getBody());
-                intentToLawsuitForm.putExtra("id", sms.getId());
+          view -> {
+            Intent intentToLawsuitForm = new Intent(view.getContext(), LawsuitActivity.class);
+            // TODO: Check if preferably to pass the SmsMessage.Proto object itself, rather than its
+            // fields.
+            intentToLawsuitForm.putExtra("receivedAt", sms.getReceivedAt());
+            intentToLawsuitForm.putExtra("from", sms.getSender());
+            intentToLawsuitForm.putExtra("body", sms.getBody());
+            intentToLawsuitForm.putExtra("id", sms.getId());
 
-                view.getContext().startActivity(intentToLawsuitForm);
-              });
+            view.getContext().startActivity(intentToLawsuitForm);
+          });
 
       // If user is had suggested this spam - Toggle "Undo suggestion" / Add suggestion options.
       toggleUndoButton(sms);
 
       buttonUndoSuggestion.setOnClickListener(
-              v -> {
-                SmsMessages.get().undoSuggestion(sms);
-              });
+          v -> {
+            SmsMessages.get().undoSuggestion(sms);
+          });
 
       buttonAddSuggestion.setOnClickListener(
-              view -> {
-                SmsMessages.get().suggestMessage(sms);
-              });
+          view -> {
+            SmsMessages.get().suggestMessage(sms);
+          });
     }
 
     // Displays the "Undo suggestion" button, in case user had suggested this message.
-    public void toggleUndoButton (SmsMessage smsMessage){
+    public void toggleUndoButton(SmsMessage smsMessage) {
       if (smsMessage
-              .getSuggestersList()
-              .contains(FirebaseAuthentication.getInstance().getCurrentUserId())) {
+          .getSuggestersList()
+          .contains(FirebaseAuthentication.getInstance().getCurrentUserId())) {
         buttonAddSuggestion.setVisibility(View.INVISIBLE);
         buttonUndoSuggestion.setVisibility((View.VISIBLE));
       } else {
@@ -183,6 +210,6 @@ public class SpamRecyclerAdapter
         buttonUndoSuggestion.setVisibility((View.INVISIBLE));
       }
     }
-
   }
 }
+

--- a/projects/noloan/app/src/main/java/hasadna/noloan/mainactivity/InboxFragment.java
+++ b/projects/noloan/app/src/main/java/hasadna/noloan/mainactivity/InboxFragment.java
@@ -53,10 +53,12 @@ public class InboxFragment extends Fragment {
 
               @Override
               public void messageModified(int index) {
-                if (SmsMessages.get()
-                        .searchInboxMessage(SmsMessages.get().getDbMessages().get(index))
-                    != -1) {
-                  getActivity().runOnUiThread(() -> inboxRecyclerAdapter.notifyItemChanged(index));
+                int inboxIndex =
+                    SmsMessages.get()
+                        .searchInboxMessage(SmsMessages.get().getDbMessages().get(index));
+                if (inboxIndex != -1) {
+                  getActivity()
+                      .runOnUiThread(() -> inboxRecyclerAdapter.notifyItemChanged(inboxIndex));
                 }
               }
 

--- a/projects/noloan/app/src/main/java/hasadna/noloan/mainactivity/MainActivity.java
+++ b/projects/noloan/app/src/main/java/hasadna/noloan/mainactivity/MainActivity.java
@@ -25,17 +25,19 @@ import java.util.ArrayList;
 import java.util.Date;
 
 import hasadna.noloan.AboutActivity;
+import hasadna.noloan.SpamRecyclerAdapter;
 import hasadna.noloan.common.SmsMessages;
 import hasadna.noloan.protobuf.SmsProto.SmsMessage;
 import noloan.R;
 
 public class MainActivity extends AppCompatActivity
-    implements NavigationView.OnNavigationItemSelectedListener,
+        implements NavigationView.OnNavigationItemSelectedListener,
         InboxFragment.OnFragmentInteractionListener,
         SpamFragment.OnFragmentInteractionListener {
 
   private static final String TAG = "MainActivity";
 
+  SpamFragment spamFragment;
   private DrawerLayout drawerLayout;
   TabLayout tabLayout;
   TextView statusTitle;
@@ -61,12 +63,12 @@ public class MainActivity extends AppCompatActivity
     // drawerLayout
     drawerLayout = findViewById(R.id.drawer_layout);
     ActionBarDrawerToggle toggle =
-        new ActionBarDrawerToggle(
-            this,
-            drawerLayout,
-            toolbar,
-            R.string.navigation_drawer_open,
-            R.string.navigation_drawer_close);
+            new ActionBarDrawerToggle(
+                    this,
+                    drawerLayout,
+                    toolbar,
+                    R.string.navigation_drawer_open,
+                    R.string.navigation_drawer_close);
     drawerLayout.addDrawerListener(toggle);
     toggle.syncState();
 
@@ -94,9 +96,9 @@ public class MainActivity extends AppCompatActivity
     // RTL swiping (Along with recyclerView.setRotationY(180) in fragments)
     viewPager.setRotationY(180);
     MainActivityPagerAdapter pagerAdapter =
-        new MainActivityPagerAdapter(getSupportFragmentManager());
+            new MainActivityPagerAdapter(getSupportFragmentManager());
     InboxFragment inboxFragment = new InboxFragment();
-    SpamFragment spamFragment = new SpamFragment();
+    spamFragment = new SpamFragment();
     pagerAdapter.addFragment(inboxFragment, getString(R.string.inboxFragment_title));
     pagerAdapter.addFragment(spamFragment, getString(R.string.spamFragment_title));
     viewPager.setAdapter(pagerAdapter);
@@ -125,18 +127,18 @@ public class MainActivity extends AppCompatActivity
   ArrayList<SmsMessage> getSmsList() {
     ArrayList<SmsMessage> smsList = new ArrayList<>();
     Cursor cursor =
-        getContentResolver().query(Uri.parse("content://sms/inbox"), null, null, null, null);
+            getContentResolver().query(Uri.parse("content://sms/inbox"), null, null, null, null);
 
     if (cursor.moveToFirst()) {
       do {
         SmsMessage sms =
-            SmsMessage.newBuilder()
-                .setSender(cursor.getString(cursor.getColumnIndexOrThrow("address")))
-                .setBody(cursor.getString(cursor.getColumnIndexOrThrow("body")))
-                .setReceivedAt(
-                    new SimpleDateFormat("dd/M/yyyy")
-                        .format(new Date(cursor.getLong(cursor.getColumnIndexOrThrow("date")))))
-                .build();
+                SmsMessage.newBuilder()
+                        .setSender(cursor.getString(cursor.getColumnIndexOrThrow("address")))
+                        .setBody(cursor.getString(cursor.getColumnIndexOrThrow("body")))
+                        .setReceivedAt(
+                                new SimpleDateFormat("dd/M/yyyy")
+                                        .format(new Date(cursor.getLong(cursor.getColumnIndexOrThrow("date")))))
+                        .build();
 
         smsList.add(sms);
       } while (cursor.moveToNext());
@@ -162,18 +164,22 @@ public class MainActivity extends AppCompatActivity
   // Update the number of messages in the title - Called from recyclerViewer adapters when list
   // changes
   public void updateTitles() {
-    // Main title
-    statusTitle.setText(String.valueOf(SmsMessages.get().getDbMessages().size()));
+    // Main title - Suspicious messages found in the inbox similar to the spams in the DB (body & sender)
+    // Not necessarily the number of messages the user had suggested.
+    statusTitle.setText(String.valueOf(SmsMessages.get().countInboxSpam()));
 
-    // Tab's titles
+    // Number of messages in the inbox
     tabLayout
-        .getTabAt(0)
-        .setText(
-            getString(R.string.inboxFragment_title, SmsMessages.get().getInboxMessages().size()));
+            .getTabAt(0)
+            .setText(
+                    getString(R.string.inboxFragment_title, SmsMessages.get().getInboxMessages().size()));
+
+    // Number of messages that the user had suggested
     tabLayout
-        .getTabAt(1)
-        .setText(getString(R.string.spamFragment_title, SmsMessages.get().getDbMessages().size()));
+            .getTabAt(1)
+            .setText(getString(R.string.spamFragment_title, spamFragment!=null ? spamFragment.spamRecyclerAdapter.getItemCount(): -1));
   }
+
 
   private void openAbout() {
     AboutActivity.startActivity(this);
@@ -182,4 +188,3 @@ public class MainActivity extends AppCompatActivity
   @Override
   public void onFragmentInteraction(Uri uri) {}
 }
-

--- a/projects/noloan/app/src/main/java/hasadna/noloan/mainactivity/MainActivity.java
+++ b/projects/noloan/app/src/main/java/hasadna/noloan/mainactivity/MainActivity.java
@@ -31,7 +31,7 @@ import hasadna.noloan.protobuf.SmsProto.SmsMessage;
 import noloan.R;
 
 public class MainActivity extends AppCompatActivity
-        implements NavigationView.OnNavigationItemSelectedListener,
+    implements NavigationView.OnNavigationItemSelectedListener,
         InboxFragment.OnFragmentInteractionListener,
         SpamFragment.OnFragmentInteractionListener {
 
@@ -63,12 +63,12 @@ public class MainActivity extends AppCompatActivity
     // drawerLayout
     drawerLayout = findViewById(R.id.drawer_layout);
     ActionBarDrawerToggle toggle =
-            new ActionBarDrawerToggle(
-                    this,
-                    drawerLayout,
-                    toolbar,
-                    R.string.navigation_drawer_open,
-                    R.string.navigation_drawer_close);
+        new ActionBarDrawerToggle(
+            this,
+            drawerLayout,
+            toolbar,
+            R.string.navigation_drawer_open,
+            R.string.navigation_drawer_close);
     drawerLayout.addDrawerListener(toggle);
     toggle.syncState();
 
@@ -96,7 +96,7 @@ public class MainActivity extends AppCompatActivity
     // RTL swiping (Along with recyclerView.setRotationY(180) in fragments)
     viewPager.setRotationY(180);
     MainActivityPagerAdapter pagerAdapter =
-            new MainActivityPagerAdapter(getSupportFragmentManager());
+        new MainActivityPagerAdapter(getSupportFragmentManager());
     InboxFragment inboxFragment = new InboxFragment();
     spamFragment = new SpamFragment();
     pagerAdapter.addFragment(inboxFragment, getString(R.string.inboxFragment_title));
@@ -127,18 +127,18 @@ public class MainActivity extends AppCompatActivity
   ArrayList<SmsMessage> getSmsList() {
     ArrayList<SmsMessage> smsList = new ArrayList<>();
     Cursor cursor =
-            getContentResolver().query(Uri.parse("content://sms/inbox"), null, null, null, null);
+        getContentResolver().query(Uri.parse("content://sms/inbox"), null, null, null, null);
 
     if (cursor.moveToFirst()) {
       do {
         SmsMessage sms =
-                SmsMessage.newBuilder()
-                        .setSender(cursor.getString(cursor.getColumnIndexOrThrow("address")))
-                        .setBody(cursor.getString(cursor.getColumnIndexOrThrow("body")))
-                        .setReceivedAt(
-                                new SimpleDateFormat("dd/M/yyyy")
-                                        .format(new Date(cursor.getLong(cursor.getColumnIndexOrThrow("date")))))
-                        .build();
+            SmsMessage.newBuilder()
+                .setSender(cursor.getString(cursor.getColumnIndexOrThrow("address")))
+                .setBody(cursor.getString(cursor.getColumnIndexOrThrow("body")))
+                .setReceivedAt(
+                    new SimpleDateFormat("dd/M/yyyy")
+                        .format(new Date(cursor.getLong(cursor.getColumnIndexOrThrow("date")))))
+                .build();
 
         smsList.add(sms);
       } while (cursor.moveToNext());
@@ -164,22 +164,25 @@ public class MainActivity extends AppCompatActivity
   // Update the number of messages in the title - Called from recyclerViewer adapters when list
   // changes
   public void updateTitles() {
-    // Main title - Suspicious messages found in the inbox similar to the spams in the DB (body & sender)
+    // Main title - Suspicious messages found in the inbox similar to the spams in the DB (body &
+    // sender)
     // Not necessarily the number of messages the user had suggested.
     statusTitle.setText(String.valueOf(SmsMessages.get().countInboxSpam()));
 
     // Number of messages in the inbox
     tabLayout
-            .getTabAt(0)
-            .setText(
-                    getString(R.string.inboxFragment_title, SmsMessages.get().getInboxMessages().size()));
+        .getTabAt(0)
+        .setText(
+            getString(R.string.inboxFragment_title, SmsMessages.get().getInboxMessages().size()));
 
     // Number of messages that the user had suggested
     tabLayout
-            .getTabAt(1)
-            .setText(getString(R.string.spamFragment_title, spamFragment!=null ? spamFragment.spamRecyclerAdapter.getItemCount(): -1));
+        .getTabAt(1)
+        .setText(
+            getString(
+                R.string.spamFragment_title,
+                spamFragment != null ? spamFragment.spamRecyclerAdapter.getItemCount() : -1));
   }
-
 
   private void openAbout() {
     AboutActivity.startActivity(this);
@@ -188,3 +191,4 @@ public class MainActivity extends AppCompatActivity
   @Override
   public void onFragmentInteraction(Uri uri) {}
 }
+

--- a/projects/noloan/app/src/main/java/hasadna/noloan/mainactivity/MainActivity.java
+++ b/projects/noloan/app/src/main/java/hasadna/noloan/mainactivity/MainActivity.java
@@ -181,7 +181,7 @@ public class MainActivity extends AppCompatActivity
         .setText(
             getString(
                 R.string.spamFragment_title,
-                spamFragment != null ? spamFragment.spamRecyclerAdapter.getItemCount() : 0));
+                spamFragment != null ? spamFragment.getSpamCount() : 0));
   }
 
   private void openAbout() {

--- a/projects/noloan/app/src/main/java/hasadna/noloan/mainactivity/MainActivity.java
+++ b/projects/noloan/app/src/main/java/hasadna/noloan/mainactivity/MainActivity.java
@@ -169,19 +169,19 @@ public class MainActivity extends AppCompatActivity
     // Not necessarily the number of messages the user had suggested.
     statusTitle.setText(String.valueOf(SmsMessages.get().countInboxSpam()));
 
-    // Number of messages in the inbox
+    // Inbox tab title
     tabLayout
         .getTabAt(0)
         .setText(
             getString(R.string.inboxFragment_title, SmsMessages.get().getInboxMessages().size()));
 
-    // Number of messages that the user had suggested
+    // Spam tab title
     tabLayout
         .getTabAt(1)
         .setText(
             getString(
                 R.string.spamFragment_title,
-                spamFragment != null ? spamFragment.spamRecyclerAdapter.getItemCount() : -1));
+                spamFragment != null ? spamFragment.spamRecyclerAdapter.getItemCount() : 0));
   }
 
   private void openAbout() {

--- a/projects/noloan/app/src/main/java/hasadna/noloan/mainactivity/SpamFragment.java
+++ b/projects/noloan/app/src/main/java/hasadna/noloan/mainactivity/SpamFragment.java
@@ -14,13 +14,14 @@ import hasadna.noloan.SpamRecyclerAdapter;
 import noloan.R;
 
 public class SpamFragment extends Fragment {
+  static final String TAG = "SpamFragment";
 
   private OnFragmentInteractionListener fragmentInteractionListener;
   private RecyclerView recyclerView;
-  private SpamRecyclerAdapter spamRecyclerAdapter;
+  SpamRecyclerAdapter spamRecyclerAdapter;
 
   public SpamFragment() {
-    // Required empty public constructor
+    spamRecyclerAdapter = new SpamRecyclerAdapter();
   }
 
   public static InboxFragment newInstance() {
@@ -35,26 +36,27 @@ public class SpamFragment extends Fragment {
 
   @Override
   public View onCreateView(
-      LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+          LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.fragment_spam, container, false);
 
     recyclerView = rootView.findViewById(R.id.RecyclerView_spamMessages);
     recyclerView.setRotationY(180);
     spamRecyclerAdapter.registerAdapterDataObserver(
-        new RecyclerView.AdapterDataObserver() {
-          @Override
-          public void onItemRangeInserted(int positionStart, int itemCount) {
-            ((MainActivity) getActivity()).updateTitles();
-          }
+            new RecyclerView.AdapterDataObserver() {
+              @Override
+              public void onItemRangeInserted(int positionStart, int itemCount) {
+                ((MainActivity) getActivity()).updateTitles();
+              }
 
-          @Override
-          public void onItemRangeRemoved(int positionStart, int itemCount) {
-            ((MainActivity) getActivity()).updateTitles();
-          }
-        });
+              @Override
+              public void onItemRangeRemoved(int positionStart, int itemCount) {
+                ((MainActivity) getActivity()).updateTitles();
+              }
+            });
 
     recyclerView.setAdapter(spamRecyclerAdapter);
     recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+    ((MainActivity) getActivity()).updateTitles();
 
     return rootView;
   }
@@ -66,7 +68,7 @@ public class SpamFragment extends Fragment {
       fragmentInteractionListener = (OnFragmentInteractionListener) context;
     } else {
       throw new RuntimeException(
-          context.toString() + " must implement OnFragmentInteractionListener");
+              context.toString() + " must implement OnFragmentInteractionListener");
     }
   }
 
@@ -80,4 +82,3 @@ public class SpamFragment extends Fragment {
     void onFragmentInteraction(Uri uri);
   }
 }
-

--- a/projects/noloan/app/src/main/java/hasadna/noloan/mainactivity/SpamFragment.java
+++ b/projects/noloan/app/src/main/java/hasadna/noloan/mainactivity/SpamFragment.java
@@ -36,23 +36,23 @@ public class SpamFragment extends Fragment {
 
   @Override
   public View onCreateView(
-          LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+      LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.fragment_spam, container, false);
 
     recyclerView = rootView.findViewById(R.id.RecyclerView_spamMessages);
     recyclerView.setRotationY(180);
     spamRecyclerAdapter.registerAdapterDataObserver(
-            new RecyclerView.AdapterDataObserver() {
-              @Override
-              public void onItemRangeInserted(int positionStart, int itemCount) {
-                ((MainActivity) getActivity()).updateTitles();
-              }
+        new RecyclerView.AdapterDataObserver() {
+          @Override
+          public void onItemRangeInserted(int positionStart, int itemCount) {
+            ((MainActivity) getActivity()).updateTitles();
+          }
 
-              @Override
-              public void onItemRangeRemoved(int positionStart, int itemCount) {
-                ((MainActivity) getActivity()).updateTitles();
-              }
-            });
+          @Override
+          public void onItemRangeRemoved(int positionStart, int itemCount) {
+            ((MainActivity) getActivity()).updateTitles();
+          }
+        });
 
     recyclerView.setAdapter(spamRecyclerAdapter);
     recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
@@ -68,7 +68,7 @@ public class SpamFragment extends Fragment {
       fragmentInteractionListener = (OnFragmentInteractionListener) context;
     } else {
       throw new RuntimeException(
-              context.toString() + " must implement OnFragmentInteractionListener");
+          context.toString() + " must implement OnFragmentInteractionListener");
     }
   }
 
@@ -82,3 +82,4 @@ public class SpamFragment extends Fragment {
     void onFragmentInteraction(Uri uri);
   }
 }
+

--- a/projects/noloan/app/src/main/java/hasadna/noloan/mainactivity/SpamFragment.java
+++ b/projects/noloan/app/src/main/java/hasadna/noloan/mainactivity/SpamFragment.java
@@ -18,7 +18,7 @@ public class SpamFragment extends Fragment {
 
   private OnFragmentInteractionListener fragmentInteractionListener;
   private RecyclerView recyclerView;
-  SpamRecyclerAdapter spamRecyclerAdapter;
+  private SpamRecyclerAdapter spamRecyclerAdapter;
 
   public SpamFragment() {
     spamRecyclerAdapter = new SpamRecyclerAdapter();
@@ -76,6 +76,10 @@ public class SpamFragment extends Fragment {
   public void onDetach() {
     super.onDetach();
     fragmentInteractionListener = null;
+  }
+
+  int getSpamCount() {
+    return spamRecyclerAdapter.getItemCount();
   }
 
   public interface OnFragmentInteractionListener {

--- a/projects/noloan/common/src/main/java/hasadna/noloan/common/SmsMessages.java
+++ b/projects/noloan/common/src/main/java/hasadna/noloan/common/SmsMessages.java
@@ -234,11 +234,11 @@ public class SmsMessages {
   }
 
   // Number of spam messages found in the user's inbox by body & sender
-  public int countInboxSpam(){
-    int count = 0 ;
-    for(int i=0; i<inboxMessages.size();i++){
-      if(searchDbMessage(inboxMessages.get(i))!=-1){
-        count ++;
+  public int countInboxSpam() {
+    int count = 0;
+    for (int i = 0; i < inboxMessages.size(); i++) {
+      if (searchDbMessage(inboxMessages.get(i)) != -1) {
+        count++;
       }
     }
 

--- a/projects/noloan/common/src/main/java/hasadna/noloan/common/SmsMessages.java
+++ b/projects/noloan/common/src/main/java/hasadna/noloan/common/SmsMessages.java
@@ -42,7 +42,7 @@ public class SmsMessages {
     // 1. Add user as a "suggester"
     int index = searchDbMessage(smsMessage);
     if ((index != -1)
-        && dbMessages
+        && !dbMessages
             .get(index)
             .getSuggestersList()
             .contains(FirebaseAuthentication.getInstance().getCurrentUserId())) {
@@ -58,8 +58,8 @@ public class SmsMessages {
 
       // Notify
       notifyListeners(dbMessages.indexOf(newMessage), newMessage, Type.MODIFIED);
-
     }
+
     // Case: New suggestion
     else if (index == -1) {
       firestoreClient.writeMessage(
@@ -231,6 +231,18 @@ public class SmsMessages {
 
   public void setInboxMessages(List<SmsMessage> inboxMessages) {
     this.inboxMessages = inboxMessages;
+  }
+
+  // Number of spam messages found in the user's inbox by body & sender
+  public int countInboxSpam(){
+    int count = 0 ;
+    for(int i=0; i<inboxMessages.size();i++){
+      if(searchDbMessage(inboxMessages.get(i))!=-1){
+        count ++;
+      }
+    }
+
+    return count;
   }
 
   public interface MessagesListener {


### PR DESCRIPTION
Spam fragment displays only SMS spams that exists in the DB and exists also in the user's inbox.

`SpamRecyclerAdapter` holds a list `inboxSpam` intersected from the spams in the DB, compared by body & sender to the user's inbox messages.


Main title / Spam tab title - Displays number of messages found "similar" (body & sender) in the DB.
(Spam tab shows only messages that are in the inbox)
Inbox title - Number of messages found in the inbox.