### PR TITLE
Add: Suggesting spam companies

### DIFF
--- a/projects/noloan/app/src/main/java/hasadna/noloan/lawsuit/fragments/LawsuitFormFragment.java
+++ b/projects/noloan/app/src/main/java/hasadna/noloan/lawsuit/fragments/LawsuitFormFragment.java
@@ -20,7 +20,9 @@ import android.widget.TextView;
 
 import java.util.Calendar;
 
+import hasadna.noloan.common.SmsMessages;
 import hasadna.noloan.lawsuit.LawsuitActivity;
+import hasadna.noloan.protobuf.CompanyProto.Company;
 import noloan.R;
 
 public class LawsuitFormFragment extends Fragment {
@@ -156,15 +158,15 @@ public class LawsuitFormFragment extends Fragment {
 
     // Company
     ((EditText) getView().findViewById(R.id.EditText_companyName))
-        .setText(lawsuitActivity.lawsuitProto.getCompanyName());
+        .setText(lawsuitActivity.lawsuitProto.getCompany().getName());
     ((EditText) getView().findViewById(R.id.EditText_companyId))
-        .setText(lawsuitActivity.lawsuitProto.getCompanyId());
+        .setText(lawsuitActivity.lawsuitProto.getCompany().getId());
     ((EditText) getView().findViewById(R.id.EditText_companyAddress))
-        .setText(lawsuitActivity.lawsuitProto.getCompanyAddress());
+        .setText(lawsuitActivity.lawsuitProto.getCompany().getAddress());
     ((EditText) getView().findViewById(R.id.EditText_companyPhone))
-        .setText(lawsuitActivity.lawsuitProto.getCompanyPhone());
+        .setText(lawsuitActivity.lawsuitProto.getCompany().getPhone());
     ((EditText) getView().findViewById(R.id.EditText_companyFax))
-        .setText(lawsuitActivity.lawsuitProto.getCompanyFax());
+        .setText(lawsuitActivity.lawsuitProto.getCompany().getFax());
 
     // General
     ((EditText) getView().findViewById(R.id.EditText_receivedSpamDate))
@@ -197,6 +199,7 @@ public class LawsuitFormFragment extends Fragment {
 
   // Update LawsuitProto with form's fields
   private void createLawsuitProto() {
+
     lawsuitActivity.lawsuitProto =
         lawsuitActivity
             .lawsuitProto
@@ -219,20 +222,29 @@ public class LawsuitFormFragment extends Fragment {
                 ((EditText) getView().findViewById(R.id.EditText_userPhone)).getText().toString())
 
             // Company
-            .setCompanyName(
-                ((EditText) getView().findViewById(R.id.EditText_companyName)).getText().toString())
-            .setCompanyId(
-                ((EditText) getView().findViewById(R.id.EditText_companyId)).getText().toString())
-            .setCompanyAddress(
-                ((EditText) getView().findViewById(R.id.EditText_companyAddress))
-                    .getText()
-                    .toString())
-            .setCompanyPhone(
-                ((EditText) getView().findViewById(R.id.EditText_companyPhone))
-                    .getText()
-                    .toString())
-            .setCompanyFax(
-                ((EditText) getView().findViewById(R.id.EditText_companyFax)).getText().toString())
+            .setCompany(
+                Company.newBuilder()
+                    .setName(
+                        ((EditText) getView().findViewById(R.id.EditText_companyName))
+                            .getText()
+                            .toString())
+                    .setId(
+                        ((EditText) getView().findViewById(R.id.EditText_companyId))
+                            .getText()
+                            .toString())
+                    .setAddress(
+                        ((EditText) getView().findViewById(R.id.EditText_companyAddress))
+                            .getText()
+                            .toString())
+                    .setPhone(
+                        ((EditText) getView().findViewById(R.id.EditText_companyPhone))
+                            .getText()
+                            .toString())
+                    .setFax(
+                        ((EditText) getView().findViewById(R.id.EditText_companyFax))
+                            .getText()
+                            .toString())
+                    .build())
 
             // General
             .setDateReceived(

--- a/projects/noloan/app/src/main/java/hasadna/noloan/mainactivity/MainActivity.java
+++ b/projects/noloan/app/src/main/java/hasadna/noloan/mainactivity/MainActivity.java
@@ -78,18 +78,6 @@ public class MainActivity extends AppCompatActivity
     NavigationView navigationView = findViewById(R.id.nav_view);
     navigationView.setNavigationItemSelectedListener(this);
 
-    /**
-     * At the moment all spams/dbMessages received from the DB are displayed to the user TODO:
-     * Intersect spams/dbMessages with user's inbox messages, display only the relevant messages
-     * that are in the inbox.
-     *
-     * <p>// Create a list of the intersection between the two lists, messages and spam // Based on
-     * https://www.baeldung.com/java-lists-intersection List<SmsMessage> spamAndInbox =
-     * inbox.stream().distinct().filter(spams::contains).collect(Collectors.toList());
-     * List<SmsMessage> suggestionsAndInbox =
-     * inbox.stream().distinct().filter(dbMessages::contains).collect(Collectors.toList());
-     */
-
     // Status title
     statusTitle = findViewById(R.id.textView_numberOfMessages);
 

--- a/projects/noloan/common/src/main/proto/Company.proto
+++ b/projects/noloan/common/src/main/proto/Company.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package hasadna.noloan;
+
+option java_package = "hasadna.noloan.protobuf";
+option java_outer_classname = "CompanyProto";
+
+message Company{
+    string name = 1;
+    string id = 2;
+    string address = 3;
+    string phone = 4;
+    string fax = 5;
+    bool approved = 6;
+
+    // List of Firestore user IDs that have suggested this spam company
+    repeated string suggesters = 7;
+
+}

--- a/projects/noloan/common/src/main/proto/Lawsuit.proto
+++ b/projects/noloan/common/src/main/proto/Lawsuit.proto
@@ -4,6 +4,7 @@ package hasadna.noloan;
 
 import "Court.proto";
 import "Sms.proto";
+import "Company.proto";
 
 option java_package = "hasadna.noloan.protobuf";
 option java_outer_classname = "LawsuitProto";
@@ -15,17 +16,12 @@ message Lawsuit {
     string userAddress = 4;
     string userPhone = 5;
 
-    string companyName = 6;
-    string companyId = 7;
-    string companyAddress = 8;
-    string companyPhone = 9;
-    string companyFax = 10;
-
     string dateReceived = 11;
     string claimAmount = 12;
     bool sentHaser = 13;
     bool moreThanFiveClaims = 14;
 
     SmsMessage smsMessage = 15;
-    Court court = 16;
+    Company company = 16;
+    Court court = 17;
 }

--- a/projects/noloan/common/src/main/proto/Sms.proto
+++ b/projects/noloan/common/src/main/proto/Sms.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package hasadna.noloan;
 
+import "Company.proto";
+
 option java_package = "hasadna.noloan.protobuf";
 option java_outer_classname = "SmsProto";
 
@@ -14,6 +16,10 @@ message SmsMessage {
 
     // List of Firestore user IDs that have suggested this message as spam.
     repeated string suggesters = 7;
+
+    // List of suggested companies for this message
+    repeated Company company = 8;
+
 }
 
 message SpamList {


### PR DESCRIPTION
Adding suggested companies to a spam in the DB.

1. Create a new `Company.proto`:
```
    string name = 1;
    string id = 2;
    string address = 3;
    string phone = 4;
    string fax = 5;
    bool approved = 6;
    repeated string suggesters = 7;
```
* Suggesters List works and functions the same as in:
`SmsMessage.suggesters`
Each company proto holds a list of anonymousIDs of suggesters - This is required in order to have an undo feature for suggested companies.
* At the moment there's no undo option for the user - This function is in this PR though for future purpose.
* Companies are suggested "from" LawsuitForms that are filled in and that are associated with a spam that the user had suggested.
Meaning: Suggesting a spam -> Suggests the company well.
If users suggest a spam - If they fill in the "company" part in the lawsuit form - It will update the companies suggested for this spam. 

2. Adding the list of companies to the `SmsMessage.proto`:
```
    message SmsMessage {
    ...
    ...

    repeated Company company = 8;
```

3. Two main functions added to `SmsMessages`:
`suggestCompany(SmsMessage smsMessage, Company company)`
`undoCompanySuggestion(SmsMessage smsMessage, Company company)` (Not in use yet)

Another help function for searching:
`searchCompany(Company company, List<Company> list)`
Needed for searching a company only by a company's relevant fields.
(Excluding DB related fields such as: `suggestersList`)
* Name
* ID
* Address
* Phone
* Fax

IMO  comparing with Address / Phone / Fax, can be optional in the future, I left it there until we feel more "stability" working with the Company.proto.

All other changes in the PR are just custom changes to working with these changes above.